### PR TITLE
Update AMI

### DIFF
--- a/config/agoradev/develop/agora-bastian.yaml
+++ b/config/agoradev/develop/agora-bastian.yaml
@@ -15,4 +15,4 @@ parameters:
   # Name of an existing EC2 KeyPair to enable SSH access to the instance
   KeyName: "agora-ci"
   # (Optional) ID of the base AMI (supported distros: AWS linux)
-  AMIId: ami-0d685c71102bf400b      # AMI with mongo db tools
+  AMIId: ami-05b72d008a5718961     # AMI with mongo and synapse tools

--- a/templates/bastian.yaml
+++ b/templates/bastian.yaml
@@ -53,6 +53,7 @@ Resources:
       ImageId: !Ref AMIId
       InstanceType: !Ref InstanceType
       KeyName: !Ref KeyName
+      PropagateTagsToVolumeOnCreation: true
       IamInstanceProfile: !Ref InstanceProfile
       SubnetId: !ImportValue
         'Fn::Sub': '${AWS::Region}-${VpcName}-${VpcSubnet}'


### PR DESCRIPTION
* Use AMI fromn imagecentral with mongo & synapse tools
  This allows both agoradev and agoraprod accounts to share
  the same AMI.
* Update template to tag the EC2 volume