### PR TITLE
Enable beanstalk auto updates

### DIFF
--- a/templates/beanstalk.yaml
+++ b/templates/beanstalk.yaml
@@ -321,6 +321,19 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: DISABLE_OPENCOLLECTIVE
           Value: !Ref DisableOpencollective
+        # ELB solution stack scheduled updates
+        - Namespace: 'aws:elasticbeanstalk:managedactions'
+          OptionName: ManagedActionsEnabled
+          Value: true
+        - Namespace: 'aws:elasticbeanstalk:managedactions'
+          OptionName: PreferredStartTime
+          Value: Sun:21:00
+        - Namespace: 'aws:elasticbeanstalk:managedactions:platformupdate'
+          OptionName: UpdateLevel
+          Value: minor
+        - Namespace: 'aws:elasticbeanstalk:managedactions:platformupdate'
+          OptionName: InstanceRefreshEnabled
+          Value: false
   BeanstalkEnvironment:
     Type: 'AWS::ElasticBeanstalk::Environment'
     Properties:


### PR DESCRIPTION
Let AWS automatically update the beanstalk solution stack every
week to keep the application running on the latest patched version
of the AWS nodejs solution stack.