### PR TITLE
Allow SSM session manager access

### DIFF
--- a/templates/beanstalk.yaml
+++ b/templates/beanstalk.yaml
@@ -347,6 +347,7 @@ Resources:
               - 'sts:AssumeRole'
       Path: /
       ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
         - 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier'
         - 'arn:aws:iam::aws:policy/AmazonSNSFullAccess'
         - 'arn:aws:iam::aws:policy/AmazonSESFullAccess'


### PR DESCRIPTION
Agora developers need to access beanstalk instances for debugging.
We need to add a policy to the instances to allow devs to access
beanstalk instances with the AWS SSM session manager[1].

[1] https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-prerequisites.html