### PR TITLE
Revert "Fix path in alb-redirector.yaml"

### DIFF
--- a/config/agoradev/develop/alb-redirector.yaml
+++ b/config/agoradev/develop/alb-redirector.yaml
@@ -2,7 +2,7 @@ template:
   path: alb-redirector.yaml
 stack_name: agora-dev-alb-redirector
 dependencies:
-  - agoradev/develop/agora.yaml
+  - develop/agora.yaml
 parameters:
   ListenerArn: "arn:aws:elasticloadbalancing:us-east-1:607346494281:listener/app/awseb-AWSEB-N08JADX0RT38/96cce8aaafaf091a/d737981cbd867081"
   RedirectFromHost: "agora-develop.ampadportal.org"


### PR DESCRIPTION
Reverts Sage-Bionetworks/agora2-infra#13.

Upon further investigation I think the DNS for agora2 is
more simple than agora therefore I don't think this change along
with PR #12 is actually needed. Let's remove to verify.