### PR TITLE
[IT-3266] Close ports on bastian hosts

### DIFF
--- a/templates/bastian.yaml
+++ b/templates/bastian.yaml
@@ -59,8 +59,6 @@ Resources:
         'Fn::Sub': '${AWS::Region}-${VpcName}-${VpcSubnet}'
       SecurityGroupIds:
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-${VpcName}-BastianSecurityGroup'
-        - !ImportValue
           'Fn::Sub': '${AWS::Region}-agora-docdb-${Environment}-DocumentDbAccessSecurityGroup'
       Tags:
         - Key: "ManagedInstanceMaintenanceTarget"


### PR DESCRIPTION
The bastian security group allow SSH access.  We can now close that access by setting up self hosted runners in GH actions.  This will make the hosts more secure.

depends on https://github.com/Sage-Bionetworks/agora-data-manager/pull/116