### PR TITLE
[IT-3266] Move bastian host into private subnet

### DIFF
--- a/config/agoradev/develop/agora-bastian.yaml
+++ b/config/agoradev/develop/agora-bastian.yaml
@@ -12,7 +12,7 @@ parameters:
   # Name of an the environment either develop, staging or prod
   Environment: "develop"
   # Name of an existing VPC subnet to run the instance in
-  VpcSubnet: "PublicSubnet"
+  VpcSubnet: "PrivateSubnet"
   # Name of an existing EC2 KeyPair to enable SSH access to the instance
   KeyName: "agora-ci"
   # (Optional) ID of the base AMI (supported distros: AWS linux)

--- a/config/agoraprod/prod/agora-bastian.yaml
+++ b/config/agoraprod/prod/agora-bastian.yaml
@@ -12,7 +12,7 @@ parameters:
   # Name of an the environment either develop, staging or prod
   Environment: "prod"
   # Name of an existing VPC subnet to run the instance in
-  VpcSubnet: "PublicSubnet"
+  VpcSubnet: "PrivateSubnet"
   # Name of an existing EC2 KeyPair to enable SSH access to the instance
   KeyName: "agora-ci"
   # (Optional) ID of the base AMI (supported distros: AWS linux)

--- a/config/agoraprod/staging/agora-bastian.yaml
+++ b/config/agoraprod/staging/agora-bastian.yaml
@@ -12,7 +12,7 @@ parameters:
   # Name of an the environment either develop, staging or prod
   Environment: "staging"
   # Name of an existing VPC subnet to run the instance in
-  VpcSubnet: "PublicSubnet"
+  VpcSubnet: "PrivateSubnet"
   # Name of an existing EC2 KeyPair to enable SSH access to the instance
   KeyName: "agora-ci"
   # (Optional) ID of the base AMI (supported distros: AWS linux)


### PR DESCRIPTION
We switch to using GH self hosted runner therefore the bastian hosts do not need to be accessible from the internet anymore.

depends on https://github.com/Sage-Bionetworks/agora-data-manager/pull/116
