### PR TITLE
AG-1568: Update default bastion InstanceType to t3.micro

### DIFF
--- a/config/agoradev/develop/agora-bastian.yaml
+++ b/config/agoradev/develop/agora-bastian.yaml
@@ -8,7 +8,6 @@ dependencies:
   - agoradev/develop/agora.yaml
   - agoradev/develop/agoravpc.yaml
 parameters:
-  InstanceType: t3.micro
   VpcName: "agoravpc"
   # Name of an the environment either develop, staging or prod
   Environment: "develop"

--- a/templates/bastian.yaml
+++ b/templates/bastian.yaml
@@ -10,7 +10,7 @@ Parameters:
   InstanceType:
     Description: WebServer EC2 instance type
     Type: String
-    Default: t3.nano
+    Default: t3.micro
     AllowedValues:
       - t3.nano
       - t3.micro


### PR DESCRIPTION
[Updating the Agora dev environment to use the t3.micro instance](https://github.com/Sage-Bionetworks/agora2-infra/pull/28) type [resolved the issue](https://github.com/Sage-Bionetworks/agora-data-manager/actions/runs/11675129659) with failed data deployments documented in [AG-1568](https://sagebionetworks.jira.com/browse/AG-1568). Therefore, we want to apply this change across all of the Agora environments, so that we can deploy data to them.

[AG-1568]: https://sagebionetworks.jira.com/browse/AG-1568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ