### PR TITLE
[IT-3964] Deploy new agora bastians

### DIFF
--- a/config/agoradev/develop/agora-bastian.yaml
+++ b/config/agoradev/develop/agora-bastian.yaml
@@ -16,4 +16,4 @@ parameters:
   # Name of an existing EC2 KeyPair to enable SSH access to the instance
   KeyName: "agora-ci"
   # (Optional) ID of the base AMI (supported distros: AWS linux)
-  AMIId: ami-05b72d008a5718961     # AMI with mongo and synapse tools
+  AMIId: ami-055ca5683a7880ef2      # AMI with mongo, synapse and Github hosted runner tools

--- a/config/agoraprod/prod/agora-bastian.yaml
+++ b/config/agoraprod/prod/agora-bastian.yaml
@@ -16,4 +16,4 @@ parameters:
   # Name of an existing EC2 KeyPair to enable SSH access to the instance
   KeyName: "agora-ci"
   # (Optional) ID of the base AMI (supported distros: AWS linux)
-  AMIId: ami-05b72d008a5718961     # AMI with mongo and synapse tools
+  AMIId: ami-055ca5683a7880ef2      # AMI with mongo, synapse and Github hosted runner tools

--- a/config/agoraprod/staging/agora-bastian.yaml
+++ b/config/agoraprod/staging/agora-bastian.yaml
@@ -16,4 +16,4 @@ parameters:
   # Name of an existing EC2 KeyPair to enable SSH access to the instance
   KeyName: "agora-ci"
   # (Optional) ID of the base AMI (supported distros: AWS linux)
-  AMIId: ami-05b72d008a5718961     # AMI with mongo and synapse tools
+  AMIId: ami-055ca5683a7880ef2      # AMI with mongo, synapse and Github hosted runner tools


### PR DESCRIPTION
The updated bastians contain the latest versions
of mongo db tools, synapse client and github hosted runner tools